### PR TITLE
OMS-N: Add service 'overlay' to service_contexts

### DIFF
--- a/service.te
+++ b/service.te
@@ -81,6 +81,7 @@ type network_score_service, system_api_service, system_server_service, service_m
 type network_time_update_service, system_server_service, service_manager_type;
 type notification_service, app_api_service, system_server_service, service_manager_type;
 type otadexopt_service, system_server_service, service_manager_type;
+type overlay_service, app_api_service, system_server_service, service_manager_type;
 type package_service, app_api_service, system_server_service, service_manager_type;
 type permission_service, app_api_service, system_server_service, service_manager_type;
 type persistent_data_block_service, system_api_service, system_server_service, service_manager_type;

--- a/service_contexts
+++ b/service_contexts
@@ -93,6 +93,7 @@ network_time_update_service               u:object_r:network_time_update_service
 nfc                                       u:object_r:nfc_service:s0
 notification                              u:object_r:notification_service:s0
 otadexopt                                 u:object_r:otadexopt_service:s0
+overlay                                   u:object_r:overlay_service:s0
 package                                   u:object_r:package_service:s0
 permission                                u:object_r:permission_service:s0
 persistent_data_block                     u:object_r:persistent_data_block_service:s0

--- a/system_server.te
+++ b/system_server.te
@@ -441,6 +441,7 @@ allow system_server mediacodec_service:service_manager find;
 allow system_server mediadrmserver_service:service_manager find;
 allow system_server netd_service:service_manager find;
 allow system_server nfc_service:service_manager find;
+allow system_server overlay_service:service_manager find;
 allow system_server radio_service:service_manager find;
 allow system_server system_server_service:service_manager { add find };
 allow system_server surfaceflinger_service:service_manager find;


### PR DESCRIPTION
The 'overlay' service is the Overlay Manager Service, which tracks
packages and their Runtime Resource Overlay overlay packages.

Bug: 31052947

Co-authored-by: Martin Wallgren <martin.wallgren@sonymobile.com>
Signed-off-by: Zoran Jovanovic <zoran.jovanovic@sonymobile.com>

Change-Id: Ie996707dd02166325271bee49163ac263e560a1d